### PR TITLE
feat/#6 : 콘서트 별 일정 조회 기능 구현

### DIFF
--- a/src/main/java/com/inity/tickenity/domain/concert/entity/Concert.java
+++ b/src/main/java/com/inity/tickenity/domain/concert/entity/Concert.java
@@ -1,0 +1,40 @@
+package com.inity.tickenity.domain.concert.entity;
+
+import com.inity.tickenity.domain.schedule.entity.Schedule;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "concert")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Concert {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "title", nullable = false)
+    private String title;
+
+    @Column(name = "age_rating", nullable = false)
+    private String ageRating;
+
+    @Column(name = "duration", nullable = false)
+    private int duration;
+
+    @Column(name = "genre", nullable = false)
+    private String genre;
+
+    @Column(name = "description", nullable = false)
+    private String description;
+
+    @Column(name = "poster_url", nullable = false)
+    private String posterUrl;
+
+}

--- a/src/main/java/com/inity/tickenity/domain/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/inity/tickenity/domain/schedule/controller/ScheduleController.java
@@ -1,0 +1,26 @@
+package com.inity.tickenity.domain.schedule.controller;
+
+import com.inity.tickenity.domain.schedule.dto.response.ScheduleResponseDto;
+import com.inity.tickenity.domain.schedule.service.ScheduleService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/concerts")
+public class ScheduleController {
+
+    private final ScheduleService scheduleService;
+
+    @GetMapping("/{concertId}/schedules")
+    public List<ScheduleResponseDto> getSchedules(@PathVariable Long concertId) {
+        return scheduleService.getSchedulesByConcert(concertId);
+    }
+
+}
+

--- a/src/main/java/com/inity/tickenity/domain/schedule/dto/response/ScheduleResponseDto.java
+++ b/src/main/java/com/inity/tickenity/domain/schedule/dto/response/ScheduleResponseDto.java
@@ -1,0 +1,9 @@
+package com.inity.tickenity.domain.schedule.dto.response;
+
+import java.time.LocalDateTime;
+
+public record ScheduleResponseDto(
+        Long scheduleId,
+        LocalDateTime startTime,
+        LocalDateTime endTime
+){}

--- a/src/main/java/com/inity/tickenity/domain/schedule/entity/Schedule.java
+++ b/src/main/java/com/inity/tickenity/domain/schedule/entity/Schedule.java
@@ -1,0 +1,33 @@
+package com.inity.tickenity.domain.schedule.entity;
+
+import com.inity.tickenity.domain.concert.entity.Concert;
+import jakarta.annotation.PostConstruct;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "schedules")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Schedule {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "concert_id", nullable = false)
+    private Concert concert;
+
+    @Column(name = "start_time", nullable = false)
+    private LocalDateTime startTime;
+
+    @Column(name = "end_time", nullable = false)
+    private LocalDateTime endTime;
+
+
+}

--- a/src/main/java/com/inity/tickenity/domain/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/com/inity/tickenity/domain/schedule/repository/ScheduleRepository.java
@@ -1,0 +1,12 @@
+package com.inity.tickenity.domain.schedule.repository;
+
+import com.inity.tickenity.domain.common.repository.BaseRepository;
+import com.inity.tickenity.domain.schedule.entity.Schedule;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ScheduleRepository extends BaseRepository<Schedule, Long> {
+    List<Schedule> findByConcertId(Long concertId);
+}

--- a/src/main/java/com/inity/tickenity/domain/schedule/service/ScheduleService.java
+++ b/src/main/java/com/inity/tickenity/domain/schedule/service/ScheduleService.java
@@ -1,0 +1,26 @@
+package com.inity.tickenity.domain.schedule.service;
+
+import com.inity.tickenity.domain.schedule.dto.response.ScheduleResponseDto;
+import com.inity.tickenity.domain.schedule.entity.Schedule;
+import com.inity.tickenity.domain.schedule.repository.ScheduleRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class ScheduleService {
+    private final ScheduleRepository scheduleRepository;
+
+    public List<ScheduleResponseDto> getSchedulesByConcert(Long concertId) {
+        List<Schedule> schedules = scheduleRepository.findByConcertId(concertId);
+        return schedules.stream()
+                .map(s -> new ScheduleResponseDto(s.getId(), s.getStartTime(), s.getEndTime()))
+                .toList();
+    }
+
+
+}


### PR DESCRIPTION
<!-- 
  📌 PR 제목 작성 가이드
  형식: {태그}/#{이슈번호} : 간단한 설명
  예시: feat/#12 : 로그인 API 연동
-->


## 🔎 작업 내용
공연 예매 시스템에서 사용자가 콘서트를 선택했을 때 해당 콘서트의 전체 일정을 조회합니다.

  <br/>

## ➕ 트러블 슈팅
도커랑 dev-yml 파일 ..... 환경세팅 ... ? 좀 해멨는데 도움 받아서 해결했습니다 ... !!! -> 이 부분 나중에 공부해볼게용
더미 데이터 임시로 넣어서 테스트 했습니다.
![image](https://github.com/user-attachments/assets/d6ea7bca-93f8-4c4f-b66b-411baa6fc101)

  <br/>

## 🔧 해결해야할 문제

- 구현이나 동작에는 문제가 없지만
- 리팩토링이나 사소한 문제가 있다면 이곳에 적어주세요.

  <br/>

<br/>
