### PR TITLE
feat/#14 : 콘서트 별 특정 일정의 좌석표 조회

### DIFF
--- a/src/main/java/com/inity/tickenity/domain/reservation/entity/Reservation.java
+++ b/src/main/java/com/inity/tickenity/domain/reservation/entity/Reservation.java
@@ -3,6 +3,8 @@ package com.inity.tickenity.domain.reservation.entity;
 import com.inity.tickenity.domain.common.entity.BaseTimeEntity;
 import com.inity.tickenity.domain.reservation.enums.PaymentStatus;
 import com.inity.tickenity.domain.reservation.enums.ReservationStatus;
+import com.inity.tickenity.domain.schedule.entity.Schedule;
+import com.inity.tickenity.domain.seat.entity.SeatInformation;
 import com.inity.tickenity.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.Builder;
@@ -30,13 +32,14 @@ public class Reservation extends BaseTimeEntity {
     private User user;
 
     // 추후에 연관관계 설정
-//    @OneToOne
-//    @JoinColumn(name = "seat_id", unique = true)
-//    private SeatInformation seatInformation;
+    @OneToOne
+    @JoinColumn(name = "seat_id", unique = true)
+    private SeatInformation seatInformation;
 
-//    @ManyToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name = "concert_schedule_id", nullable = false)
-//    private ConcertSchedule concertSchedule;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "schedule_id", nullable = false)
+    private Schedule schedule;
+
 
     // Builder
     @Builder

--- a/src/main/java/com/inity/tickenity/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/inity/tickenity/domain/reservation/repository/ReservationRepository.java
@@ -9,6 +9,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Set;
+
 public interface ReservationRepository extends BaseRepository<Reservation, Long> {
 
     @Query("SELECT new com.inity.tickenity.domain.reservation.dto.response.MyReservationResponse(r.id, r.createdAt, r.reservationStatus) " +
@@ -18,4 +20,12 @@ public interface ReservationRepository extends BaseRepository<Reservation, Long>
     @Query("SELECT new com.inity.tickenity.domain.reservation.dto.response.ReservationDetailResponseDto(r.id, r.createdAt, r.modifiedAt, r.reservationStatus, r.paymentStatus) " +
             "FROM Reservation r WHERE r.id = :reservationId")
     ReservationDetailResponseDto findByReservationWithDto(@Param("reservationId") Long reservationId);
+
+    @Query("""
+    SELECT r.seatInformation.number FROM Reservation r
+    WHERE r.schedule.id = :scheduleId AND r.reservationStatus = 'RESERVED'
+""")
+    Set<String> findReservedSeatNumbers(@Param("scheduleId") Long scheduleId);
+
+
 }

--- a/src/main/java/com/inity/tickenity/domain/schedule/controller/ScheduleSeatController.java
+++ b/src/main/java/com/inity/tickenity/domain/schedule/controller/ScheduleSeatController.java
@@ -1,0 +1,33 @@
+package com.inity.tickenity.domain.schedule.controller;
+
+import com.inity.tickenity.domain.schedule.dto.response.SeatResponseDto;
+import com.inity.tickenity.domain.schedule.service.ScheduleSeatService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/concerts/{concertId}/schedules")
+@RequiredArgsConstructor
+public class ScheduleSeatController {
+
+    private final ScheduleSeatService scheduleSeatService;
+
+    @GetMapping("/{scheduleId}/seats")
+    public ResponseEntity<?> getSeatList(
+            @PathVariable Long concertId,
+            @PathVariable Long scheduleId) {
+
+        List<SeatResponseDto> seatList = scheduleSeatService.getSeatsForSchedule(concertId, scheduleId);
+        return ResponseEntity.ok(Map.of(
+                "scheduleId", scheduleId,
+                "seats", seatList
+        ));
+    }
+}

--- a/src/main/java/com/inity/tickenity/domain/schedule/dto/response/SeatResponseDto.java
+++ b/src/main/java/com/inity/tickenity/domain/schedule/dto/response/SeatResponseDto.java
@@ -1,0 +1,11 @@
+package com.inity.tickenity.domain.schedule.dto.response;
+
+import com.inity.tickenity.domain.seat.enums.SeatGradeType;
+
+public record SeatResponseDto(
+        String seatId,
+        SeatGradeType grade,
+        int price,
+        boolean isReserved
+) {
+}

--- a/src/main/java/com/inity/tickenity/domain/schedule/service/ScheduleSeatService.java
+++ b/src/main/java/com/inity/tickenity/domain/schedule/service/ScheduleSeatService.java
@@ -1,0 +1,51 @@
+package com.inity.tickenity.domain.schedule.service;
+
+import com.inity.tickenity.domain.reservation.repository.ReservationRepository;
+import com.inity.tickenity.domain.schedule.dto.response.SeatResponseDto;
+import com.inity.tickenity.domain.seat.entity.SeatGradePrice;
+import com.inity.tickenity.domain.seat.entity.SeatInformation;
+import com.inity.tickenity.domain.seat.enums.SeatGradeType;
+import com.inity.tickenity.domain.seat.repository.SeatGradePriceRepository;
+import com.inity.tickenity.domain.seat.repository.SeatInformationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ScheduleSeatService {
+
+    private final SeatInformationRepository seatInformationRepository;
+    private final SeatGradePriceRepository seatGradePriceRepository;
+    private final ReservationRepository reservationRepository;
+
+    public List<SeatResponseDto> getSeatsForSchedule(Long concertId, Long scheduleId) {
+
+        // 1. 콘서트장에 존재하는 좌석 목록 조회
+        List<SeatInformation> seats = seatInformationRepository.findByConcertId(concertId);
+
+        // 2. 해당 콘서트의 등급별 가격 정보 조회
+        Map<SeatGradeType, Integer> gradeToPrice = seatGradePriceRepository.findByConcertId(concertId).stream()
+                .collect(Collectors.toMap(
+                        SeatGradePrice::getGrade,
+                        SeatGradePrice::getPrice
+                ));
+
+        // 3. 해당 일정에서 예약된 좌석 번호 목록 조회
+        Set<String> reservedNumbers = reservationRepository.findReservedSeatNumbers(scheduleId);
+
+        // 4. 응답 변환
+        return seats.stream()
+                .map(seat -> new SeatResponseDto(
+                        seat.getNumber(),
+                        seat.getGrade(),
+                        gradeToPrice.get(seat.getGrade()),
+                        reservedNumbers.contains(seat.getNumber())
+                ))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/inity/tickenity/domain/seat/entity/SeatGradePrice.java
+++ b/src/main/java/com/inity/tickenity/domain/seat/entity/SeatGradePrice.java
@@ -1,0 +1,31 @@
+package com.inity.tickenity.domain.seat.entity;
+
+import com.inity.tickenity.domain.concert.entity.Concert;
+import com.inity.tickenity.domain.seat.enums.SeatGradeType;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "seat_grade_price")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SeatGradePrice {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "concert_id", nullable = false)
+    private Concert concert;
+
+    @Column(name = "price", nullable = false)
+    private int price;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private SeatGradeType grade;
+
+}

--- a/src/main/java/com/inity/tickenity/domain/seat/entity/SeatInformation.java
+++ b/src/main/java/com/inity/tickenity/domain/seat/entity/SeatInformation.java
@@ -1,0 +1,32 @@
+package com.inity.tickenity.domain.seat.entity;
+
+import com.inity.tickenity.domain.seat.enums.SeatGradeType;
+import com.inity.tickenity.domain.venue.entity.Venue;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "seat_information")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SeatInformation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "venue_id", nullable = false)
+    private Venue venue;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private SeatGradeType grade;
+
+
+    @Column(name = "number", nullable = false)
+    private String number;
+
+}

--- a/src/main/java/com/inity/tickenity/domain/seat/enums/SeatGradeType.java
+++ b/src/main/java/com/inity/tickenity/domain/seat/enums/SeatGradeType.java
@@ -1,0 +1,5 @@
+package com.inity.tickenity.domain.seat.enums;
+
+public enum SeatGradeType {
+    VIP, R, S, A, B
+}

--- a/src/main/java/com/inity/tickenity/domain/seat/repository/SeatGradePriceRepository.java
+++ b/src/main/java/com/inity/tickenity/domain/seat/repository/SeatGradePriceRepository.java
@@ -1,0 +1,12 @@
+package com.inity.tickenity.domain.seat.repository;
+
+import com.inity.tickenity.domain.common.repository.BaseRepository;
+import com.inity.tickenity.domain.seat.entity.SeatGradePrice;
+
+
+import java.util.List;
+
+public interface SeatGradePriceRepository extends BaseRepository<SeatGradePrice, Long> {
+
+    List<SeatGradePrice> findByConcertId(Long concertId);
+}

--- a/src/main/java/com/inity/tickenity/domain/seat/repository/SeatInformationRepository.java
+++ b/src/main/java/com/inity/tickenity/domain/seat/repository/SeatInformationRepository.java
@@ -1,0 +1,22 @@
+package com.inity.tickenity.domain.seat.repository;
+
+import com.inity.tickenity.domain.common.repository.BaseRepository;
+import com.inity.tickenity.domain.seat.entity.SeatInformation;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface SeatInformationRepository extends BaseRepository<SeatInformation, Long> {
+
+    @Query(value = """
+SELECT si.*
+FROM seat_information si
+JOIN venues v ON si.venue_id = v.id
+JOIN concert_venue cv ON cv.venue_id = v.id
+JOIN concerts c ON c.id = cv.concert_id
+WHERE c.id = :concertId
+""", nativeQuery = true)
+    List<SeatInformation> findByConcertId(@Param("concertId") Long concertId);
+
+}


### PR DESCRIPTION
<!-- 
  📌 PR 제목 작성 가이드
  형식: {태그}/#{이슈번호} : 간단한 설명
  예시: feat/#12 : 로그인 API 연동
-->


## 🔎 작업 내용
closes #14 
콘서트 별 특정 일정의 좌석표 조회를 구현했습니다.

  <br/>

## ➕ 트러블 슈팅
▶️ `SeatInformationRepository`

```java
    @Query(value = """
SELECT si.*
FROM seat_information si
JOIN venues v ON si.venue_id = v.id
JOIN concert_venue cv ON cv.venue_id = v.id
JOIN concerts c ON c.id = cv.concert_id
WHERE c.id = :concertId
""", nativeQuery = true)
    List<SeatInformation> findByConcertId(@Param("concertId") Long concertId);

}
```

좌석 정보에서 콘서트 ID에 대한 정보를 가져오기 위해서는 `좌석 정보 → 장소 → (장소와 콘서트의 중간 테이블) → 콘서트` 이렇게 정보를 가져와야했기 때문에 JPQL이 아니라 네이티브 쿼리를 사용했습니다.



  <br/>

## 🔧 해결해야할 문제
콘서트 별 특정 일정의 좌석표 조회 API를 SeatController와 ScheduleController 중 어느 위치에서 구현할까 고민을 많이 했는데, 결론적으로 ScheduleSeatController 에서 하게 되었습니다.

좌석에 구현하자니, "좌석표"는 일정에 따라 좌석의 상태(예: 예매 여부 등)가 달라지므로 관심사에 어긋난다고 생각했고,  ScheduleController는 일정 정보 자체에 집중되어야 한다고 생각해서 각각의 위치에서 구현하지 않았습니다.

따라서 일정에 따른  좌석 상태 조회/관리 전용으로 ScheduleSeatController에서 구현했는데 혹시 더 좋은 생각이 있다면 의견 주세요 !!

  <br/>

<br/>

## 포스트맨 캡처 사진
![image](https://github.com/user-attachments/assets/d05db2ec-4718-4aae-9d17-e4b68c3b270d)