### PR TITLE
feat/#27 : concurrency testcode

### DIFF
--- a/src/main/java/com/inity/tickenity/domain/reservation/entity/Reservation.java
+++ b/src/main/java/com/inity/tickenity/domain/reservation/entity/Reservation.java
@@ -14,6 +14,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor
+@Table(name = "reservations")
 public class Reservation extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -31,8 +32,8 @@ public class Reservation extends BaseTimeEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @OneToOne
-    @JoinColumn(name = "seat_id", unique = true)
+    @ManyToOne
+    @JoinColumn(name = "seat_information_id")
     private SeatInformation seatInformation;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/inity/tickenity/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/inity/tickenity/domain/reservation/repository/ReservationRepository.java
@@ -32,4 +32,8 @@ public interface ReservationRepository extends BaseRepository<Reservation, Long>
     WHERE r.schedule.id = :scheduleId AND r.reservationStatus = 'RESERVED'
     """)
     Set<String> findReservedSeatNumbers(@Param("scheduleId") Long scheduleId);
+
+    boolean existsBySchedule_IdAndSeatInformation_Id(Long scheduleId, Long seatInformationId);
+
+    long count();
 }

--- a/src/main/java/com/inity/tickenity/domain/reservation/service/ReservationService.java
+++ b/src/main/java/com/inity/tickenity/domain/reservation/service/ReservationService.java
@@ -108,9 +108,11 @@ public class ReservationService {
     /**
      * Reservation 카운트 해주는 메서드
      */
-    public void countReservation() {
+    public Long countReservation() {
+        Long result = reservationRepository.count();
         System.out.println("\n\n\n====================\n");
-        System.out.println(reservationRepository.count());
+        System.out.println(result);
         System.out.println("\n====================\n\n\n");
+        return result;
     }
 }

--- a/src/main/java/com/inity/tickenity/domain/schedule/entity/Schedule.java
+++ b/src/main/java/com/inity/tickenity/domain/schedule/entity/Schedule.java
@@ -1,7 +1,6 @@
 package com.inity.tickenity.domain.schedule.entity;
 
 import com.inity.tickenity.domain.concert.entity.Concert;
-import jakarta.annotation.PostConstruct;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -30,4 +29,9 @@ public class Schedule {
     private LocalDateTime endTime;
 
 
+    public Schedule(Concert concert, LocalDateTime startTime, LocalDateTime endTime) {
+        this.concert = concert;
+        this.startTime = startTime;
+        this.endTime = endTime;
+    }
 }

--- a/src/main/java/com/inity/tickenity/domain/seat/entity/SeatGradePrice.java
+++ b/src/main/java/com/inity/tickenity/domain/seat/entity/SeatGradePrice.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "seat_grade_price")
+@Table(name = "seat_grade_prices")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class SeatGradePrice {

--- a/src/main/java/com/inity/tickenity/domain/seat/entity/SeatInformation.java
+++ b/src/main/java/com/inity/tickenity/domain/seat/entity/SeatInformation.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "seat_information")
+@Table(name = "seat_informations")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class SeatInformation {
@@ -29,4 +29,9 @@ public class SeatInformation {
     @Column(name = "number", nullable = false)
     private String number;
 
+    public SeatInformation(Venue venue, SeatGradeType grade, String number) {
+        this.venue = venue;
+        this.grade = grade;
+        this.number = number;
+    }
 }

--- a/src/main/java/com/inity/tickenity/domain/user/entity/User.java
+++ b/src/main/java/com/inity/tickenity/domain/user/entity/User.java
@@ -10,6 +10,7 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
 
 @Entity
+@Table(name = "users")
 @Getter
 @SQLDelete(sql = "UPDATE users SET is_deleted = true WHERE id = ?")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/test/java/com/inity/tickenity/domain/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/com/inity/tickenity/domain/reservation/service/ReservationServiceTest.java
@@ -1,0 +1,138 @@
+package com.inity.tickenity.domain.reservation.service;
+
+import com.inity.tickenity.domain.concert.entity.Concert;
+import com.inity.tickenity.domain.concert.enums.Genre;
+import com.inity.tickenity.domain.concert.repository.ConcertRepository;
+import com.inity.tickenity.domain.reservation.dto.reqeust.ReservationCreateRequestDto;
+import com.inity.tickenity.domain.schedule.entity.Schedule;
+import com.inity.tickenity.domain.schedule.repository.ScheduleRepository;
+import com.inity.tickenity.domain.seat.entity.SeatInformation;
+import com.inity.tickenity.domain.seat.enums.SeatGradeType;
+import com.inity.tickenity.domain.seat.repository.SeatInformationRepository;
+import com.inity.tickenity.domain.user.entity.User;
+import com.inity.tickenity.domain.user.enums.UserRole;
+import com.inity.tickenity.domain.user.repository.UserRepository;
+import com.inity.tickenity.domain.venue.entity.Venue;
+import com.inity.tickenity.domain.venue.repository.VenueRepository;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+@Disabled("임시로 비활성화")
+@SpringBootTest
+class ReservationServiceTest {
+
+    @Autowired
+    private ReservationService reservationService;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private SeatInformationRepository seatInformationRepository;
+    @Autowired
+    private ScheduleRepository scheduleRepository;
+    @Autowired
+    private VenueRepository venueRepository;
+    @Autowired
+    private ConcertRepository concertRepository;
+
+    @BeforeEach
+    void setUp() {
+        // 1. 장소 저장
+        Venue venue = venueRepository.save(new Venue("address", "name", 45, "tt"));
+        // 2. 콘서트 저장
+        Concert concert = concertRepository.save(new Concert("test", "전체이용가", 23, Genre.CLASSICAL, "t", "url"));
+        // 3. 일정 저장
+        scheduleRepository.save(new Schedule(concert, LocalDateTime.now(), LocalDateTime.now()));
+        // 4. 좌석 정보 저장
+        seatInformationRepository.save(new SeatInformation(venue, SeatGradeType.VIP, "A1"));
+        // 5. 유저 정보 저장
+        IntStream.range(0, 1000).forEach(i -> {
+            userRepository.save(new User(i + "test@test.com", "pwd", "test", "000-0000-0000", UserRole.USER));
+        });
+    }
+
+    @Disabled("임시로 비활성화")
+    @DisplayName("동일 좌석에 대한 동시 예약 시 하나만 성공해야 한다 - Callable")
+    @Test
+    void shouldAllowOnlyOneReservationWhenMultipleUsersReserveSameSeatConcurrently() throws InterruptedException {
+        System.out.println("\n\n\n\n[createReservation Test]");
+        // ---------------------------
+        // given: 예약 요청 정보 및 스레드풀 설정
+        // ---------------------------
+        ReservationCreateRequestDto reservationCreateRequestDto = new ReservationCreateRequestDto(1L, 1L);
+
+        ExecutorService executor = Executors.newFixedThreadPool(16);
+
+        List<Callable<Void>> tasks = IntStream.range(0, 1000)
+                .mapToObj(i -> (Callable<Void>) () -> {
+                    reservationService.createReservation((long) i + 1, reservationCreateRequestDto);
+                    return null;
+                }).collect(Collectors.toList());
+
+        // ---------------------------
+        // when: 1000명의 사용자가 동시에 예약 요청
+        // ---------------------------
+        executor.invokeAll(tasks);
+        executor.shutdown();
+
+        // ---------------------------
+        // then: 성공한 예약은 정확히 1건이어야 함
+        // 지금은 실패
+        // ---------------------------
+        Assertions.assertEquals(1L, reservationService.countReservation());
+    }
+
+    @Disabled("임시로 비활성화")
+    @DisplayName("동일 좌석에 대한 동시 예약 시 하나만 성공해야 한다 - CountDownLatch")
+    @Test
+    void shouldAllowOnlyOneReservationWhenMultipleUsersReserveSameSeatConcurrentlyWithCountDownLatch() throws InterruptedException {
+        System.out.println("\n\n\n\n[createReservation Test with CountDownLatch]");
+
+        // ---------------------------
+        // given: 예약 요청 정보 및 스레드풀 설정
+        // ---------------------------
+        ReservationCreateRequestDto reservationCreateRequestDto = new ReservationCreateRequestDto(1L, 1L);
+
+        ExecutorService executor = Executors.newFixedThreadPool(16);
+        int tryCount = 1000;
+
+        AtomicInteger successCount = new AtomicInteger();
+        AtomicInteger failCount = new AtomicInteger();
+        CountDownLatch latch = new CountDownLatch(tryCount);
+
+        // ---------------------------
+        // when: 1000명의 사용자가 동시에 예약 요청
+        // ---------------------------
+        for (int i = 0; i < tryCount; i++) {
+            int finalI = i;
+            executor.submit(() -> {
+                try {
+                    reservationService.createReservation(1L + finalI, reservationCreateRequestDto);
+                    successCount.getAndIncrement();
+                } catch (Exception e) {
+                    System.out.println("[error]  : " + e.getMessage());
+                    failCount.getAndIncrement();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+        executor.shutdown();
+
+        // ---------------------------
+        // then: 성공한 예약은 정확히 1건이어야 함
+        // 지금은 실패
+        // ---------------------------
+        // 실패 나는 게 정상 입니다.
+        Assertions.assertEquals(1L, reservationService.countReservation());
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -2,14 +2,14 @@ spring:
     config:
         import: optional:file:.env[.properties]
     datasource:
-        url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+        url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=1;DB_CLOSE_ON_EXIT=FALSE;DATABASE_TO_UPPER=false
         driver-class-name: org.h2.Driver
         username: sa
         password:
     jpa:
         hibernate:
             ddl-auto: create-drop
-        show-sql: false
+        show-sql: true
 
 jwt:
     secret:


### PR DESCRIPTION
<!-- 
  📌 PR 제목 작성 가이드
  형식: {태그}/#{이슈번호} : 간단한 설명
  예시: feat/#12 : 로그인 API 연동
-->


## 🔎 작업 내용

- 테스트 코드 작성

  <br/>

## ➕ 트러블 슈팅

1. 문제상황
- 동시성 제어가 DB 딴에서 되고 있는 상황이다. 
```
2025-05-22T10:58:35.748+09:00 ERROR 29472 --- [ool-3-thread-12] o.h.engine.jdbc.spi.SqlExceptionHelper   : Unique index or primary key violation: "PUBLIC.CONSTRAINT_INDEX_4 ON PUBLIC.RESERVATIONS(SEAT_INFORMATION_ID NULLS FIRST) VALUES ( /* 2 */ CAST(1 AS BIGINT) )"; SQL statement:
insert into reservations (created_at,modified_at,payment_status,reservation_status,schedule_id,seat_information_id,user_id,id) values (?,?,?,?,?,?,?,default) [23505-232]
2025-05-22T10:58:35.748+09:00  WARN 29472 --- [pool-3-thread-5] o.h.engine.jdbc.spi.SqlExceptionHelper   : SQL Error: 23505, SQLState: 23505
2025-05-22T10:58:35.748+09:00  WARN 29472 --- [pool-3-thread-6] o.h.engine.jdbc.spi.SqlExceptionHelper   : SQL Error: 23505, SQLState: 23505
2025-05-22T10:58:35.748+09:00 ERROR 29472 --- [pool-3-thread-5] o.h.engine.jdbc.spi.SqlExceptionHelper   : Unique index or primary key 
```

2. 문제 원인 분석
- unique 제약 조건이 걸려 있어서, DB 딴에서 동시성 제어가 되고 있었다.
- 문제는 우리가 `Onetoone` 으로 설정하여, `Unique` 제약 조건이 `true` 였기 때문이다.
- 우리가 다시 ERD 를 확인 해보니 좌석 정보와 예매가 1:1 관계여서 그렇게 설정했던 것이다.
- 다시 한 번, 좌석 정보와 예매와의 관계를 생각하면 좌석 정보 + 일정 조합이 예매와 1:1 인 것이지 좌석 정보와 예매가 1:1 이 아닌 것을 깨달았다.

3. 해결 방법
- ERD 를 아래와 같이 수정하고, 연관관계도 `ManyToOne` 으로 바꾸어 주었다.
![image](https://github.com/user-attachments/assets/2c3a1e96-7200-4122-800d-ba24ebe93e45)
- 정상적으로 동시성 문제가 발생하고 있는 걸 확인할 수 있다.
![image](https://github.com/user-attachments/assets/b462362c-dad9-41c7-9820-f7c9f0267f65)



  <br/>

## 🔧 해결해야할 문제

- 사용하실 때, Disabled 어노테이션 제거 후 사용해야합니다 !

  <br/>

<br/>

- close #27 