### PR TITLE
feat/#34 : 동시성 제어 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,14 @@ dependencies {
 
 	// bcrypt
 	implementation 'at.favre.lib:bcrypt:0.10.2'
+
+	// Redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'io.lettuce:lettuce-core:6.3.0.RELEASE'
+
+	// Redisson 의존성 추가
+	implementation 'org.redisson:redisson-spring-boot-starter:3.23.5'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/inity/tickenity/domain/reservation/controller/ReservationController.java
+++ b/src/main/java/com/inity/tickenity/domain/reservation/controller/ReservationController.java
@@ -19,13 +19,24 @@ import org.springframework.web.bind.annotation.*;
 public class ReservationController {
     private final ReservationService reservationService;
 
-    @PostMapping
-    public BaseResponse<ReservationIdResponseDto> createReservation(
+    @PostMapping("/lettuce")
+    public BaseResponse<ReservationIdResponseDto> createReservationWithLettuce(
             @Auth AuthUser authUser,
             @RequestBody ReservationCreateRequestDto reservationCreateRequestDto
     ) {
         return BaseResponse.success(
-                reservationService.createReservation(authUser.id(), reservationCreateRequestDto),
+                reservationService.createReservationWithLettuce(authUser.id(), reservationCreateRequestDto),
+                ResultCode.CREATED
+        );
+    }
+
+    @PostMapping("/redisson")
+    public BaseResponse<ReservationIdResponseDto> createReservationWithRedisson(
+            @Auth AuthUser authUser,
+            @RequestBody ReservationCreateRequestDto reservationCreateRequestDto
+    ) {
+        return BaseResponse.success(
+                reservationService.createReservationWithRedisson(authUser.id(), reservationCreateRequestDto),
                 ResultCode.CREATED
         );
     }

--- a/src/main/java/com/inity/tickenity/domain/reservation/service/ReservationService.java
+++ b/src/main/java/com/inity/tickenity/domain/reservation/service/ReservationService.java
@@ -7,19 +7,26 @@ import com.inity.tickenity.domain.reservation.dto.response.ReservationDetailResp
 import com.inity.tickenity.domain.reservation.dto.response.ReservationIdResponseDto;
 import com.inity.tickenity.domain.reservation.entity.Reservation;
 import com.inity.tickenity.domain.reservation.repository.ReservationRepository;
+import com.inity.tickenity.domain.schedule.entity.Schedule;
 import com.inity.tickenity.domain.schedule.repository.ScheduleRepository;
+import com.inity.tickenity.domain.seat.entity.SeatInformation;
 import com.inity.tickenity.domain.seat.repository.SeatInformationRepository;
+import com.inity.tickenity.domain.user.entity.User;
 import com.inity.tickenity.domain.user.repository.UserRepository;
 import com.inity.tickenity.global.exception.BusinessException;
 import com.inity.tickenity.global.lock.LockService;
 import com.inity.tickenity.global.response.ResultCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 
 @Service
@@ -45,9 +52,17 @@ public class ReservationService {
             ReservationCreateRequestDto reservationCreateRequestDto
     ) {
         String lockKey = "reservation:" + reservationCreateRequestDto.scheduleId() + ":" + reservationCreateRequestDto.seatInformationId();
+        String uuid = UUID.randomUUID().toString();
         AtomicReference<Reservation> savedReservation = new AtomicReference<>();
 
-        lockService.executeWithLock(lockKey, () -> {
+        // 2. 락 점유
+        boolean locked = lockService.tryLock(lockKey, uuid, 3000);
+        if (!locked) {
+            throw new BusinessException(ResultCode.LOCK_FAIL, "락 획득 실패");
+        }
+
+        try {
+            // 3. 비즈니스 로직 실행
             if (reservationRepository.existsBySchedule_IdAndSeatInformation_Id(
                     reservationCreateRequestDto.scheduleId(),
                     reservationCreateRequestDto.seatInformationId())) {
@@ -61,11 +76,23 @@ public class ReservationService {
                     .build();
 
             savedReservation.set(reservationRepository.save(reservation));
-        });
+
+            // 5. 커밋 후 락 해제 예약
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    lockService.unlock(lockKey, uuid);
+                }
+            });
+
+        } catch (Exception e) {
+            // 예외 발생 시 즉시 락 해제 (rollback 되더라도 unlock은 반드시 필요)
+            lockService.unlock(lockKey, uuid);
+            throw e;
+        }
 
         return ReservationIdResponseDto.of(savedReservation.get().getId());
     }
-
 
     /**
      * 로그인한 유저의 예매 내역을 모두 조회

--- a/src/main/java/com/inity/tickenity/global/config/RedisLettuceConfig.java
+++ b/src/main/java/com/inity/tickenity/global/config/RedisLettuceConfig.java
@@ -1,0 +1,20 @@
+package com.inity.tickenity.global.config;
+
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.api.StatefulRedisConnection;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RedisLettuceConfig {
+
+    @Bean
+    public RedisClient redisClient() {
+        return RedisClient.create("redis://localhost:6379");
+    }
+
+    @Bean
+    public StatefulRedisConnection<String, String> redisConnection(RedisClient redisClient) {
+        return redisClient.connect();
+    }
+}

--- a/src/main/java/com/inity/tickenity/global/config/RedisRedissonConfig.java
+++ b/src/main/java/com/inity/tickenity/global/config/RedisRedissonConfig.java
@@ -1,0 +1,21 @@
+package com.inity.tickenity.global.config;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RedisRedissonConfig {
+
+    @Bean
+    public RedissonClient redissonClient() {
+        Config config = new Config();
+        config.useSingleServer()
+                .setAddress("redis://localhost:6379")
+                .setConnectionMinimumIdleSize(1)
+                .setConnectionPoolSize(5);
+        return Redisson.create(config);
+    }
+}

--- a/src/main/java/com/inity/tickenity/global/lock/LettuceLock.java
+++ b/src/main/java/com/inity/tickenity/global/lock/LettuceLock.java
@@ -1,0 +1,11 @@
+package com.inity.tickenity.global.lock;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface LettuceLock {
+    String key();             // key의 SpEL 표현식
+    long timeout() default 3000; // 락 점유 시간 (ms)
+}

--- a/src/main/java/com/inity/tickenity/global/lock/LettuceLockAspect.java
+++ b/src/main/java/com/inity/tickenity/global/lock/LettuceLockAspect.java
@@ -1,0 +1,92 @@
+package com.inity.tickenity.global.lock;
+
+import com.inity.tickenity.global.exception.BusinessException;
+import com.inity.tickenity.global.response.ResultCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.core.annotation.Order;
+import org.springframework.expression.EvaluationContext;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import java.lang.reflect.Method;
+import java.util.UUID;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+@Slf4j
+@Order(1)
+public class LettuceLockAspect {
+
+    private final LockService lockService;
+    private final SpelExpressionParser parser = new SpelExpressionParser();
+
+    @Around("@annotation(redisLock)")
+    public Object applyRedisLock(ProceedingJoinPoint joinPoint, LettuceLock redisLock) throws Throwable {
+        MethodSignature methodSignature = (MethodSignature) joinPoint.getSignature();
+        Method method = methodSignature.getMethod();
+
+        EvaluationContext context = new StandardEvaluationContext();
+        String[] paramNames = methodSignature.getParameterNames();
+        Object[] args = joinPoint.getArgs();
+        for (int i = 0; i < paramNames.length; i++) {
+            context.setVariable(paramNames[i], args[i]);
+        }
+
+        String key = parser.parseExpression(redisLock.key()).getValue(context, String.class);
+        String uuid = UUID.randomUUID().toString();
+
+        log.info("[🔒 RedisLock] 락 획득 시도 - key: {}, uuid: {}", key, uuid);
+
+        boolean locked = lockService.tryLock(key, uuid, redisLock.timeout());
+        if (!locked) {
+            log.warn("[⚠️ RedisLock] 락 획득 실패 - key: {}", key);
+            throw new BusinessException(ResultCode.LOCK_FAIL, "락 획득 실패");
+        }
+
+        log.info("[✅ RedisLock] 락 획득 성공 - key: {}, uuid: {}", key, uuid);
+
+        boolean unlockRequired = true;
+
+        try {
+            Object result = joinPoint.proceed();
+
+            if (TransactionSynchronizationManager.isSynchronizationActive()) {
+                unlockRequired = false; // unlock은 afterCommit에서 수행 예정
+                TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                    @Override
+                    public void afterCommit() {
+                        lockService.unlock(key, uuid);
+                        log.info("[🔓 RedisLock] 커밋 이후 락 해제 완료 - key: {}, uuid: {}", key, uuid);
+                    }
+                });
+            } else {
+                // 트랜잭션이 없는 경우에는 즉시 해제하지 않고 unlockRequired=true 유지
+                log.warn("[RedisLock] 트랜잭션 비활성 상태에서 커밋 후 해제 불가 - key: {}, uuid: {}", key, uuid);
+            }
+
+            return result;
+
+        } catch (Exception e) {
+            // 예외 발생 시 무조건 해제
+            lockService.unlock(key, uuid);
+            log.error("[🔥 RedisLock] 예외 발생 - 락 즉시 해제 - key: {}, uuid: {}, 메시지: {}", key, uuid, e.getMessage(), e);
+            throw e;
+
+        } finally {
+            // 트랜잭션이 없고 예외도 없는 경우, 직접 해제
+            if (unlockRequired && !TransactionSynchronizationManager.isSynchronizationActive()) {
+                lockService.unlock(key, uuid);
+                log.warn("[RedisLock] 트랜잭션 없이 정상 종료된 메서드의 락 수동 해제 - key: {}, uuid: {}", key, uuid);
+            }
+        }
+    }
+}

--- a/src/main/java/com/inity/tickenity/global/lock/LockRedisRepository.java
+++ b/src/main/java/com/inity/tickenity/global/lock/LockRedisRepository.java
@@ -1,0 +1,27 @@
+package com.inity.tickenity.global.lock;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+
+@Repository
+@RequiredArgsConstructor
+public class LockRedisRepository {
+
+    private final StringRedisTemplate redisTemplate;
+
+    public Boolean lock(String key, String value, Duration timeout) {
+        return redisTemplate
+                .opsForValue()
+                .setIfAbsent(key, value, timeout); // NX 옵션 + TTL 부여
+    }
+
+    public void unlock(String key, String value) {
+        String currentValue = redisTemplate.opsForValue().get(key);
+        if (value.equals(currentValue)) {
+            redisTemplate.delete(key); // 자신이 Lock을 가지고 있을 때만 해제
+        }
+    }
+}

--- a/src/main/java/com/inity/tickenity/global/lock/LockService.java
+++ b/src/main/java/com/inity/tickenity/global/lock/LockService.java
@@ -14,20 +14,6 @@ public class LockService {
 
     private final LockRedisRepository lockRedisRepository;
 
-    public void executeWithLock(String key, Runnable task) {
-        String uuid = UUID.randomUUID().toString();
-        boolean isLocked = lockRedisRepository.lock(key, uuid, Duration.ofMillis(3000));
-
-        if (!isLocked) {
-            throw new BusinessException(ResultCode.LOCK_FAIL, "락 획득 실패");
-        }
-
-        try {
-            task.run();
-        } finally {
-            lockRedisRepository.unlock(key, uuid);
-        }
-    }
 
     public boolean tryLock(String key, String uuid, long millis) {
         return lockRedisRepository.lock(key, uuid, Duration.ofMillis(millis));

--- a/src/main/java/com/inity/tickenity/global/lock/LockService.java
+++ b/src/main/java/com/inity/tickenity/global/lock/LockService.java
@@ -1,0 +1,40 @@
+package com.inity.tickenity.global.lock;
+
+import com.inity.tickenity.global.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import com.inity.tickenity.global.response.ResultCode;
+
+import java.time.Duration;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class LockService {
+
+    private final LockRedisRepository lockRedisRepository;
+
+    public void executeWithLock(String key, Runnable task) {
+        String uuid = UUID.randomUUID().toString();
+        boolean isLocked = lockRedisRepository.lock(key, uuid, Duration.ofMillis(3000));
+
+        if (!isLocked) {
+            throw new BusinessException(ResultCode.LOCK_FAIL, "락 획득 실패");
+        }
+
+        try {
+            task.run();
+        } finally {
+            lockRedisRepository.unlock(key, uuid);
+        }
+    }
+
+    public boolean tryLock(String key, String uuid, long millis) {
+        return lockRedisRepository.lock(key, uuid, Duration.ofMillis(millis));
+    }
+
+    public void unlock(String key, String uuid) {
+        lockRedisRepository.unlock(key, uuid);
+    }
+
+}

--- a/src/main/java/com/inity/tickenity/global/lock/LockService.java
+++ b/src/main/java/com/inity/tickenity/global/lock/LockService.java
@@ -1,19 +1,15 @@
 package com.inity.tickenity.global.lock;
 
-import com.inity.tickenity.global.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import com.inity.tickenity.global.response.ResultCode;
 
 import java.time.Duration;
-import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
 public class LockService {
 
     private final LockRedisRepository lockRedisRepository;
-
 
     public boolean tryLock(String key, String uuid, long millis) {
         return lockRedisRepository.lock(key, uuid, Duration.ofMillis(millis));

--- a/src/main/java/com/inity/tickenity/global/lock/RedissonLock.java
+++ b/src/main/java/com/inity/tickenity/global/lock/RedissonLock.java
@@ -1,0 +1,12 @@
+package com.inity.tickenity.global.lock;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface RedissonLock {
+    String key();                 // key의 SpEL 표현식
+    long waitTime() default 3000; // 락 대기 시간 (ms)
+    long leaseTime() default 2000; // 락 점유 시간 (ms)
+}

--- a/src/main/java/com/inity/tickenity/global/lock/RedissonLockAspect.java
+++ b/src/main/java/com/inity/tickenity/global/lock/RedissonLockAspect.java
@@ -1,0 +1,95 @@
+package com.inity.tickenity.global.lock;
+
+import com.inity.tickenity.global.exception.BusinessException;
+import com.inity.tickenity.global.response.ResultCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.core.annotation.Order;
+import org.springframework.expression.EvaluationContext;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import java.lang.reflect.Method;
+import java.util.concurrent.TimeUnit;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+@Slf4j
+@Order(1)
+public class RedissonLockAspect {
+
+    private final RedissonClient redissonClient;
+    private final SpelExpressionParser parser = new SpelExpressionParser();
+
+    @Around("@annotation(redissonLock)")
+    public Object applyRedissonLock(ProceedingJoinPoint joinPoint, RedissonLock redissonLock) throws Throwable {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+
+        EvaluationContext context = new StandardEvaluationContext();
+        String[] paramNames = signature.getParameterNames();
+        Object[] args = joinPoint.getArgs();
+        for (int i = 0; i < paramNames.length; i++) {
+            context.setVariable(paramNames[i], args[i]);
+        }
+
+        String key = parser.parseExpression(redissonLock.key()).getValue(context, String.class);
+        RLock lock = redissonClient.getLock(key);
+
+        boolean isLocked = false;
+
+        try {
+            log.info("[🔒 RedissonLock] 락 획득 시도 - key: {}", key);
+            isLocked = lock.tryLock(redissonLock.waitTime(), redissonLock.leaseTime(), TimeUnit.MILLISECONDS);
+
+            if (!isLocked) {
+                log.warn("[⚠️ RedissonLock] 락 획득 실패 - key: {}", key);
+                throw new BusinessException(ResultCode.LOCK_FAIL, "Redisson 락 획득 실패");
+            }
+
+            log.info("[✅ RedissonLock] 락 획득 성공 - key: {}", key);
+
+            Object result = joinPoint.proceed();
+
+            if (TransactionSynchronizationManager.isSynchronizationActive()) {
+                TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                    @Override
+                    public void afterCommit() {
+                        if (lock.isHeldByCurrentThread()) {
+                            lock.unlock();
+                            log.info("[🔓 RedissonLock] 커밋 이후 락 해제 완료 - key: {}", key);
+                        }
+                    }
+                });
+            } else {
+                // 트랜잭션이 없는 경우 즉시 해제
+                if (lock.isHeldByCurrentThread()) {
+                    lock.unlock();
+                    log.warn("[RedissonLock] 트랜잭션 없이 락 즉시 해제 - key: {}", key);
+                }
+            }
+
+            return result;
+
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new BusinessException(ResultCode.LOCK_FAIL, "Redisson 락 인터럽트 예외");
+        } catch (Exception e) {
+            if (isLocked && lock.isHeldByCurrentThread()) {
+                lock.unlock();
+                log.error("[🔥 RedissonLock] 예외 발생 - 락 즉시 해제 - key: {}, 메시지: {}", key, e.getMessage(), e);
+            }
+            throw e;
+        }
+    }
+}

--- a/src/main/java/com/inity/tickenity/global/lock/RedissonLockService.java
+++ b/src/main/java/com/inity/tickenity/global/lock/RedissonLockService.java
@@ -1,0 +1,42 @@
+package com.inity.tickenity.global.lock;
+
+import com.inity.tickenity.global.exception.BusinessException;
+import com.inity.tickenity.global.response.ResultCode;
+import lombok.RequiredArgsConstructor;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class RedissonLockService {
+
+    private final RedissonClient redissonClient;
+
+    public <T> T executeWithLock(String key, long waitTime, long leaseTime, Callable<T> task) {
+        RLock lock = redissonClient.getLock(key);
+        boolean isLocked = false;
+
+        try {
+            isLocked = lock.tryLock(waitTime, leaseTime, TimeUnit.MILLISECONDS);
+            if (!isLocked) {
+                throw new BusinessException(ResultCode.LOCK_FAIL, "Redisson 락 획득 실패");
+            }
+            return task.call();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new BusinessException(ResultCode.LOCK_FAIL, "락 인터럽트 예외");
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        } finally {
+            if (isLocked && lock.isHeldByCurrentThread()) {
+                lock.unlock();
+            }
+        }
+    }
+}
+
+

--- a/src/main/java/com/inity/tickenity/global/response/ResultCode.java
+++ b/src/main/java/com/inity/tickenity/global/response/ResultCode.java
@@ -19,6 +19,9 @@ public enum ResultCode {
     VALID_FAIL(HttpStatus.BAD_REQUEST, "유효성 검증에 실패하였습니다."),
     NOT_FOUND(HttpStatus.NOT_FOUND, "NOT FOUND"),
 
+    // Lock Fail
+    LOCK_FAIL(HttpStatus.CONFLICT, "락 획득 실패"),
+
     /* 인증, 인가 */
     LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "아이디(로그인 이메일) 또는 비밀번호가 잘못 되었습니다. 아이디와 비밀번호를 정확히 입력해 주세요."),
     AUTH_ANNOTATION_USER_MISMATCH(HttpStatus.UNAUTHORIZED, "@Auth와 AuthUser 타입은 함께 사용되어야 합니다."),

--- a/src/test/java/com/inity/tickenity/domain/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/com/inity/tickenity/domain/reservation/service/ReservationServiceTest.java
@@ -17,6 +17,7 @@ import com.inity.tickenity.domain.venue.repository.VenueRepository;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -27,6 +28,7 @@ import java.util.stream.IntStream;
 
 @Disabled("임시로 비활성화")
 @SpringBootTest
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 class ReservationServiceTest {
 
     @Autowired
@@ -43,7 +45,9 @@ class ReservationServiceTest {
     private ConcertRepository concertRepository;
 
     @BeforeEach
+
     void setUp() {
+
         // 1. 장소 저장
         Venue venue = venueRepository.save(new Venue("address", "name", 45, "tt"));
         // 2. 콘서트 저장
@@ -134,5 +138,9 @@ class ReservationServiceTest {
         // ---------------------------
         // 실패 나는 게 정상 입니다.
         Assertions.assertEquals(1L, reservationService.countReservation());
+        System.out.println("성공 수: " + successCount.get());
+        System.out.println("실패 수: " + failCount.get());
+        System.out.println("예약 건수: " + reservationService.countReservation());
+
     }
 }


### PR DESCRIPTION
<!-- 
  📌 PR 제목 작성 가이드
  형식: {태그}/#{이슈번호} : 간단한 설명
  예시: feat/#12 : 로그인 API 연동
-->


## 🔎 작업 내용
close #25 
close #34

## ➕ 트러블 슈팅
5분 기록 보드에 임시로 올려두었습니다.

  <br/>

## 🔧 해결해야할 문제
현재 임시 성능 테스트를 구현했는데 Lettuce가 Redisson 보다 더 빠르게 수행되어서 의문을 가지고 있습니다. 

추가로,
1. 트랜잭션 시작
2. Redis 락 점유
3. 트랜잭션 (종료) 커밋
4. 락 해제

다음 1,2번과 관련해서 순서가 보장되지 않아도 괜찮은지 고민중입니다 !

  <br/>

<br/>

## 🧾 개인공부 정리
https://yeunever.tistory.com/48
https://github.com/iiiiiiunited/backend/wiki/%ED%95%84%EC%88%98%EA%B3%BC%EC%A0%9C-%EC%99%84%EC%84%B1
